### PR TITLE
(maint) Support new debian platforms

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,7 +155,7 @@ class java::params {
             'oracle-jre8' => $debian_oracle_jre8,
           }
         }
-        'vivid': {
+        'stretch', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic': {
           $java =  {
             'jdk'  => $debian_jdk8,
             'jre'  => $debian_jre8,


### PR DESCRIPTION
This commit adds support for codenames 'stretch', 'wily', 'xenial', 'yakkety', 'zesty', 'artful', and 'bionic'.